### PR TITLE
feat(agendamento): Implementa tela e funcionalidade para desmarcar consulta

### DIFF
--- a/frontend/cancel-appointment.html
+++ b/frontend/cancel-appointment.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Desmarcar Consulta - Promédica Saúde</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+
+    <nav class="app-nav-bar">
+        <div class="back-icon">
+            <a href="home.html" aria-label="Voltar para o menu principal"><</a>
+        </div>
+        <div class="nav-title">DESMARCAR CONSULTA</div>
+        <div class="search-icons">
+            <span><i class="fas fa-search"></i></span>
+            <span><i class="fas fa-search"></i></span>
+        </div>
+    </nav>
+
+    <main class="cancel-appointment-container">
+        <div id="appointmentList" class="appointment-cards-list">
+            
+            <div class="appointment-card" data-appointment-id="appt001">
+                <div class="card-header">
+                    <span class="location-name">Policlínica</span>
+                    <div class="date-time">
+                        <span class="date">Data <strong>28/04/2025</strong></span>
+                        <span class="time">Horário <strong>08h:00</strong></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p><strong>Serviço(s):</strong> Consulta com pneumologista</p>
+                    <p><strong>Profissional:</strong> Dr (a) João Alves</p>
+                    <p><strong>Endereço(s):</strong> Centro - Salvador / BA</p>
+                </div>
+                <div class="card-footer-info">
+                    <span class="distance">5,65 km</span>
+                </div>
+                <button class="btn btn-cancel-action">Desmarcar</button>
+            </div>
+
+            <div class="appointment-card" data-appointment-id="appt002">
+                <div class="card-header">
+                    <span class="location-name">Policlínica</span>
+                    <div class="date-time">
+                        <span class="date">Data <strong>19/05/2025</strong></span>
+                        <span class="time">Horário <strong>08h:00</strong></span>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <p><strong>Serviço(s):</strong> Consulta com cardiologista</p>
+                    <p><strong>Profissional:</strong> Dr (a) João Alves</p>
+                    <p><strong>Endereço(s):</strong> Centro - Salvador / BA</p>
+                </div>
+                <div class="card-footer-info">
+                    <span class="distance">5,65 km</span>
+                </div>
+                <button class="btn btn-cancel-action">Desmarcar</button>
+            </div>
+
+            <div id="noAppointmentsMessage" class="no-items-message" style="display: none;">
+                <p>Você não possui consultas futuras para desmarcar.</p>
+            </div>
+        </div>
+
+        <div id="cancelConfirmModal" class="modal-overlay" style="display: none;">
+            <div class="modal-content">
+                <p id="cancelConfirmText">Tem certeza que deseja desmarcar esta consulta?</p>
+                <div class="modal-actions">
+                    <button id="cancelConfirmYesBtn" class="btn btn-confirm">Sim, Desmarcar</button>
+                    <button id="cancelConfirmNoBtn" class="btn btn-cancel">Não</button>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <span>Promédica <span class="plus-icon">+</span></span>
+    </footer>
+
+    <script src="js/cancel-appointment.js"></script>
+</body>
+</html>

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -686,3 +686,100 @@ body {
 .result-item .btn-agendar:hover {
     background-color: #45a049;
 }
+
+.cancel-appointment-container {
+    flex-grow: 1;
+    padding: 0 0 20px 0;
+    background-color: #e9e9ed; 
+    width: 100%;
+    max-width: 400px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.appointment-cards-list {
+    padding: 15px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.appointment-card {
+    background-color: #FFFFFF;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    padding: 15px;
+    border-left: 5px solid #37474F;
+}
+
+.appointment-card .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 10px;
+}
+
+.appointment-card .location-name {
+    font-weight: bold;
+    font-size: 1.1em;
+    color: #333;
+}
+
+.appointment-card .date-time {
+    text-align: right;
+    font-size: 0.85em;
+    color: #555;
+}
+.appointment-card .date-time .date, 
+.appointment-card .date-time .time {
+    display: block;
+}
+.appointment-card .date-time strong {
+    color: #333;
+}
+
+.appointment-card .card-body p {
+    font-size: 0.95em;
+    color: #444;
+    margin-bottom: 6px;
+    line-height: 1.5;
+}
+.appointment-card .card-body p strong {
+    color: #333;
+}
+
+.appointment-card .card-footer-info {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-top: 10px;
+    margin-bottom: 15px;
+    font-size: 0.9em;
+}
+.appointment-card .distance {
+    font-weight: bold;
+    color: #333;
+}
+
+.btn-cancel-action {
+    background-color: #37474F;
+    color: white;
+    width: 100%;
+    padding: 12px;
+    font-size: 1.1em;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    text-transform: none;
+}
+.btn-cancel-action:hover {
+    background-color: #2C3E50;
+}
+
+.no-items-message {
+    text-align: center;
+    padding: 30px 20px;
+    font-size: 1.1em;
+    color: #777;
+}

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -51,7 +51,7 @@
                 </a>
             </li>
             <li class="menu-item">
-                <a href="#">
+                <a href="cancel-appointment.html">
                     <i class="fas fa-calendar-times menu-icon-item"></i>
                     <span>Desmarcar Consulta</span>
                 </a>

--- a/frontend/js/cancel-appointment.js
+++ b/frontend/js/cancel-appointment.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const appointmentListDiv = document.getElementById('appointmentList');
+    const cancelButtons = document.querySelectorAll('.btn-cancel-action');
+    const noAppointmentsMessage = document.getElementById('noAppointmentsMessage');
+
+    const cancelModal = document.getElementById('cancelConfirmModal');
+    const cancelConfirmYesBtn = document.getElementById('cancelConfirmYesBtn');
+    const cancelConfirmNoBtn = document.getElementById('cancelConfirmNoBtn');
+    const cancelConfirmText = document.getElementById('cancelConfirmText');
+
+    let appointmentToCancel = null;
+
+    function checkEmptyList() {
+        const remainingCards = appointmentListDiv.querySelectorAll('.appointment-card');
+        if (remainingCards.length === 0 && noAppointmentsMessage) {
+            noAppointmentsMessage.style.display = 'block';
+        } else if (noAppointmentsMessage) {
+            noAppointmentsMessage.style.display = 'none';
+        }
+    }
+    
+    checkEmptyList();
+
+    cancelButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            appointmentToCancel = this.closest('.appointment-card');
+            const professional = appointmentToCancel.querySelector('.card-body p:nth-child(2)').textContent.replace('Profissional: ', '');
+            const date = appointmentToCancel.querySelector('.date strong').textContent;
+            const time = appointmentToCancel.querySelector('.time strong').textContent;
+
+            if (cancelConfirmText) {
+                 cancelConfirmText.innerHTML = `Tem certeza que deseja desmarcar a consulta com ${professional} em ${date} às ${time}?`;
+            }
+
+            if (cancelModal) cancelModal.style.display = 'flex';
+        });
+    });
+
+    if (cancelConfirmYesBtn) {
+        cancelConfirmYesBtn.addEventListener('click', function() {
+            if (appointmentToCancel) {
+                appointmentToCancel.remove();
+                console.log('Consulta desmarcada:', appointmentToCancel.dataset.appointmentId);
+                alert('Consulta desmarcada com sucesso! (Mockado)');
+                checkEmptyList();
+            }
+            if (cancelModal) cancelModal.style.display = 'none';
+            appointmentToCancel = null;
+        });
+    }
+
+    if (cancelConfirmNoBtn) {
+        cancelConfirmNoBtn.addEventListener('click', function() {
+            if (cancelModal) cancelModal.style.display = 'none';
+            appointmentToCancel = null;
+        });
+    }
+
+    if (cancelModal) {
+        cancelModal.addEventListener('click', function(event) {
+            if (event.target === cancelModal) {
+                cancelModal.style.display = 'none';
+                appointmentToCancel = null;
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Resumo da Funcionalidade

Este Pull Request introduz a tela "Desmarcar Consulta", permitindo aos usuários visualizarem suas consultas futuras agendadas e solicitarem o cancelamento de uma consulta específica. A funcionalidade inclui um diálogo de confirmação antes de efetivar a desmarcação.

---

## Mudanças Realizadas

-   **`frontend/cancel-appointment.html`**:
    -   Criação da estrutura HTML para a tela de "Desmarcar Consulta", incluindo:
        -   Barra de navegação com título e botão de voltar para o menu principal (`home.html`).
        -   Lista (`div#appointmentList`) para exibir cards de consultas agendadas (com dados mockados).
        -   Cada card de consulta (`.appointment-card`) exibe detalhes como local, data, horário, serviço, profissional e um botão "Desmarcar".
        -   Uma mensagem (`#noAppointmentsMessage`) para ser exibida caso não haja consultas.
        -   Um modal/diálogo de confirmação (`#cancelConfirmModal`), inicialmente oculto, para confirmar a ação de desmarcar.
-   **`frontend/js/cancel-appointment.js`**:
    -   Implementação da lógica do frontend para a tela:
        -   Adiciona `eventListeners` aos botões "Desmarcar" de cada consulta.
        -   Ao clicar em "Desmarcar", exibe o modal de confirmação preenchido com detalhes da consulta selecionada.
        -   Manipula os botões "Sim, Desmarcar" e "Não" do modal:
            -   Se "Sim", remove o card da consulta da lista (visual no frontend) e exibe um `alert` de sucesso mockado.
            -   Verifica se a lista de consultas ficou vazia para exibir a mensagem apropriada.
        -   Permite fechar o modal clicando fora da área de conteúdo.
-   **`frontend/home.html`**:
    -   Atualizado o link do item de menu "Desmarcar Consulta" para direcionar corretamente para `cancel-appointment.html`.
-   **`frontend/css/style.css`**:
    -   Adicionados novos estilos para formatar a tela de desmarcar consulta, os cards de agendamento (`.cancel-appointment-container`, `.appointment-cards-list`, `.appointment-card`, `.btn-cancel-action`) e a mensagem de "sem consultas".
    -   Reutilização dos estilos do modal de confirmação definidos anteriormente, com possíveis ajustes se necessários para o contexto.

---

## HU(s) Relacionada(s)

*   Esta funcionalidade atende diretamente à **HU-007 (Implementar Desmarcação Direta de Consulta Agendada)**, que especifica a necessidade de cancelar uma consulta futura pela lista "Meus Agendamentos" (ou uma tela similar, como esta).

---

## Como Testar

1.  A partir da tela de Menu Principal (`home.html`), clique no item "**Desmarcar Consulta**".
2.  Você deve ser redirecionado para a tela `cancel-appointment.html`.
3.  Verifique se a lista mockada com duas consultas agendadas é exibida.
4.  Para uma das consultas na lista, clique no botão "**Desmarcar**".
5.  O diálogo de confirmação deve aparecer, perguntando se você tem certeza e mencionando detalhes da consulta.
6.  Clique no botão "**Não**" no diálogo. O diálogo deve fechar e a consulta deve permanecer na lista.
7.  Clique novamente no botão "**Desmarcar**" da mesma consulta.
8.  No diálogo, clique em "**Sim, Desmarcar**".
    *   A consulta deve ser removida visualmente da lista.
    *   Um `alert` mockado indicando "Consulta desmarcada com sucesso!" deve ser exibido.
9.  Desmarque a segunda consulta seguindo os mesmos passos.
10. Após desmarcar todas as consultas, a mensagem "Você não possui consultas futuras para desmarcar." deve ser exibida.
11. Verifique se o botão de voltar na barra de navegação superior retorna para `home.html`.

---

## Observações Adicionais

-   Os dados das consultas exibidas são **fixos e mockados** em `cancel-appointment.html`.
-   A ação de desmarcar apenas remove o elemento visualmente do frontend e exibe um alerta; não há interação real com um backend.
-   A funcionalidade "Remarcar" sugerida no botão do protótipo original foi simplificada para apenas "Desmarcar" neste MVP.